### PR TITLE
Handle empty scheme

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -208,7 +208,7 @@ Client.prototype._isSequenceRequired = function(methodName) {
 
 Client.prototype._setSequenceArgs = function(argsScheme, args) {
   var result = {};
-  if(typeof argsScheme !== 'object') {
+  if(typeof argsScheme !== 'object' || Object.keys(argsScheme).length <= 0) {
     return args;
   }
   for (var partIndex in argsScheme) {


### PR DESCRIPTION
A particular SOAP service I'm using has this format. This change is required to work with it.
The WSDL that has this is here: https://api.yukiworks.nl/ws/Accounting.asmx?wsdl for the method "processJournal"